### PR TITLE
Replaced `0x03` with `OUTPUT`

### DIFF
--- a/ESP32_C3_DevKitC_02/Wiring/hello_world.ino
+++ b/ESP32_C3_DevKitC_02/Wiring/hello_world.ino
@@ -4,7 +4,7 @@ void setup ()
   // put your setup code here, to run once:
   Serial.begin (115200);
   pinMode (BUILTIN_LED, 
-           0x03);
+           OUTPUT);
   digitalWrite (BUILTIN_LED, 
                 0);
   pf ("int sz\n  --> %zu\n",


### PR DESCRIPTION
*[A stackoverflow member, once said to me:](https://stackoverflow.com/questions/68200504/pangram-in-c-using-functions/68201064#comment120545032_68201064)*
> Please try to avoid [magic numbers](https://en.wikipedia.org/wiki/Magic_number_(programming))